### PR TITLE
fixes #18 : bumping play-services-vision to 15.0.1 for firebase compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-vision:15.0.1'
+    implementation 'com.google.android.gms:play-services-vision:15.0.2'
 }
 
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-vision:12.0.1'
+    implementation 'com.google.android.gms:play-services-vision:15.0.1'
 }
 
 


### PR DESCRIPTION
Bumped version of play-services-vision to 15.0.1 to ensure it pulls a compatible version to the one pulled by firebase_core (and others).

Fixes #18