### PR TITLE
In some device autofocus not happning

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,6 +3,6 @@
           package="com.github.rmtmckenzie.qrmobilevision">
 
     <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="true"/>
 
 </manifest>


### PR DESCRIPTION
In my RedMi 3S prime camera autofocus is working with required 'false'  but in Mi A2 autofocus not working. So it should be auto focus required for all devices