### PR TITLE
Fix fatal signal 11 (SIGSEGV) fault addr 0x41c

### DIFF
--- a/android/src/main/java/com/github/rmtmckenzie/qrmobilevision/QrMobileVisionPlugin.java
+++ b/android/src/main/java/com/github/rmtmckenzie/qrmobilevision/QrMobileVisionPlugin.java
@@ -71,6 +71,7 @@ public class QrMobileVisionPlugin implements MethodCallHandler, QrReaderCallback
 
     private void stopReader() {
         readingInstance.reader.stop();
+        readingInstance.textureEntry.release();
         readingInstance = null;
         lastHeartbeatTimeout = null;
     }


### PR DESCRIPTION
### Fixes fatal error:
```
A/libc: Fatal signal 11 (SIGSEGV), code 1, fault addr 0x41c in tid 23131 (Thread-13170) 
A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***                
A/DEBUG: Build fingerprint: 'samsung/kltexx/klte:6.0.1/MMB29M/G900FXXS1CQDD:user/release
A/DEBUG: Revision: '14'                                                                 
A/DEBUG: ABI: 'arm'                                                                     
A/DEBUG: pid: 22214, tid: 23131, name: Thread-13170  >>> com.replaced_package.name <<<           
A/DEBUG: signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x41c                    
A/DEBUG:     r0 0000041c  r1 00000000  r2 00000110  r3 00000001                         
A/DEBUG:     r4 0000041c  r5 00000000  r6 00000054  r7 fffffe08                         
A/DEBUG:     r8 fffffe04  r9 9d172600  sl 32de2ca0  fp 70b47410                         
A/DEBUG:     ip b6bca420  sp ae27a1c8  lr b6ba5b43  pc b6ca3f0a  cpsr 600f0030          
A/DEBUG: backtrace:                                                                     
A/DEBUG:     #00 pc 0003ff0a  /system/lib/libc.so (pthread_mutex_lock+3)                
A/DEBUG:     #01 pc 0003db3f  /system/lib/libgui.so (_ZN7android10GLConsumer17detachFrom
A/DEBUG:     #02 pc 0009d13f  /system/lib/libandroid_runtime.so                         
A/DEBUG:     #03 pc 02f57c89  /system/framework/arm/boot.oat (offset 0x2f3b000)
```         

### How to reproduce the error
On android phone. Run example app. Hit 'press me' several times. Press HOME or BACK button. The error shows up randomly. 

Tested on Samsung S5 Android 6.0.1 and Lenovo P2 Android 7.x