### PR TITLE
Handle permission denied error on iOS

### DIFF
--- a/ios/Classes/QrReader.swift
+++ b/ios/Classes/QrReader.swift
@@ -110,7 +110,7 @@ class QrReader: NSObject {
   let cameraPosition = AVCaptureDevice.Position.back
   let qrCallback: (_:String) -> Void
   
-  init(targetWidth: Int, targetHeight: Int, textureRegistry: FlutterTextureRegistry, options: VisionBarcodeDetectorOptions, qrCallback: @escaping (_:String) -> Void) {
+  init(targetWidth: Int, targetHeight: Int, textureRegistry: FlutterTextureRegistry, options: VisionBarcodeDetectorOptions, qrCallback: @escaping (_:String) -> Void) throws {
     self.targetWidth = targetWidth
     self.targetHeight = targetHeight
     self.textureRegistry = textureRegistry
@@ -138,8 +138,7 @@ class QrReader: NSObject {
       captureDevice = AVCaptureDevice.default(for: AVMediaType.video)!
     }
     
-    // catch?
-    let input = try! AVCaptureDeviceInput.init(device: captureDevice)
+    let input = try AVCaptureDeviceInput.init(device: captureDevice)
     previewSize = CMVideoFormatDescriptionGetDimensions(captureDevice.activeFormat.formatDescription)
     
     let output = AVCaptureVideoDataOutput()

--- a/ios/Classes/SwiftQrMobileVisionPlugin.swift
+++ b/ios/Classes/SwiftQrMobileVisionPlugin.swift
@@ -63,22 +63,26 @@ public class SwiftQrMobileVisionPlugin: NSObject, FlutterPlugin {
 
       let options = VisionBarcodeDetectorOptions(formatStrings: formatStrings)
             
-      reader = QrReader(
-        targetWidth: targetWidth,
-        targetHeight: targetHeight,
-        textureRegistry: textureRegistry,
-        options: options) { [unowned self] qr in
-          self.channel.invokeMethod("qrRead", arguments: qr)
+      do {
+        reader = try QrReader(
+          targetWidth: targetWidth,
+          targetHeight: targetHeight,
+          textureRegistry: textureRegistry,
+          options: options) { [unowned self] qr in
+            self.channel.invokeMethod("qrRead", arguments: qr)
+        }
+        
+        reader!.start();
+        
+        result([
+          "surfaceWidth": reader!.previewSize.height,
+          "surfaceHeight": reader!.previewSize.width,
+          "surfaceOrientation": 0, //TODO: check on iPAD
+          "textureId": reader!.textureId!
+        ])
+      } catch {
+        result(FlutterError(code: "PERMISSION_DENIED", message: "QrReader initialization threw an exception", details: error.localizedDescription))
       }
-      
-      reader!.start();
-      
-      result([
-        "surfaceWidth": reader!.previewSize.height,
-        "surfaceHeight": reader!.previewSize.width,
-        "surfaceOrientation": 0, //TODO: check on iPAD
-        "textureId": reader!.textureId!
-      ])
     case "stop":
       reader?.stop();
       reader = nil


### PR DESCRIPTION
Fixes #127 

This PR handles the case where the user refuses the Camera permission on iOS. Previously the app would crash.

![63D592A1-6A92-4B4F-A127-ECF3B983D0FB_1_105_c](https://user-images.githubusercontent.com/5110923/81649628-e6d0b500-9430-11ea-8d5e-b9b62125432f.jpeg)
![E32938B8-4DD2-4A4E-9A8A-410E0EC6BAAC_1_105_c](https://user-images.githubusercontent.com/5110923/81649639-e9330f00-9430-11ea-84e5-343e587aa7c3.jpeg)

