### PR TITLE
Remove log statement from dart code

### DIFF
--- a/lib/qr_camera.dart
+++ b/lib/qr_camera.dart
@@ -210,9 +210,6 @@ class Preview extends StatelessWidget {
             break;
         }
 
-        print(
-            "Native orientation: $nativeRotation, sensorOrientation: $sensorOrientation");
-
         int rotationCompensation =
             ((nativeRotation - sensorOrientation + 450) % 360) ~/ 90;
 


### PR DESCRIPTION
Removal of log statement in the dart code which can potentially fill up the device logs.