### PR TITLE
Take the acutal screen resolution for the camera

### DIFF
--- a/lib/qr_camera.dart
+++ b/lib/qr_camera.dart
@@ -75,8 +75,8 @@ class QrCameraState extends State<QrCamera> with WidgetsBindingObserver {
 
   Future<PreviewDetails> _asyncInit(num width, num height) async {
     var previewDetails = await QrMobileVision.start(
-      width: width.toInt(),
-      height: height.toInt(),
+      width: (MediaQuery.of(context).devicePixelRatio * width.toInt()).ceil(),
+      height: (MediaQuery.of(context).devicePixelRatio * height.toInt()).ceil(),
       qrCodeHandler: widget.qrCodeCallback,
       formats: widget.formats,
     );


### PR DESCRIPTION
Since Flutter does not use real pixels as a unit for constraints, but the native cameras do, this PR made a little change to convert the current BoxContraints to real device pixels in order to get a sharper picture.
A sharper picture, in this case, also means more accurate scans.