### PR TITLE
Avoid crash when force unwrapping the `rawValue` from a scanned feature. 

### DIFF
--- a/ios/Classes/QrReader.swift
+++ b/ios/Classes/QrReader.swift
@@ -218,7 +218,9 @@ extension QrReader: AVCaptureVideoDataOutputSampleBufferDelegate {
         }
                 
         for feature in features {
-          self.qrCallback(feature.rawValue!)
+            if let value = feature.rawValue {
+                self.qrCallback(value)
+            }
         }
       }
     }


### PR DESCRIPTION
Minor update to how we are force unwrapping `rawValue`. I couldn't reproduce this consistently, it happened a few times. Specifically it happened when I was serially scanning a bunch of types that are NOT supported and then scanned one that was. I was just using barcode-generator.org as my test site. There are a few types of barcodes you'll see there, most of them are supported but there are some like Planet/Maxicode etc that are not.

Either way not force unwrapping seems like a good idea here.
There was nothing in MLKit documentation either about the feature's `rawValue` being nil.