### PR TITLE
fix: proccess new frames even after failures

### DIFF
--- a/android/src/main/java/com/github/rmtmckenzie/qrmobilevision/QrDetector.java
+++ b/android/src/main/java/com/github/rmtmckenzie/qrmobilevision/QrDetector.java
@@ -5,8 +5,10 @@ import android.util.Log;
 import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 
+import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
 import com.google.mlkit.vision.barcode.BarcodeScanner;
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions;
 import com.google.mlkit.vision.barcode.BarcodeScanning;
@@ -72,9 +74,9 @@ class QrDetector implements OnSuccessListener<List<Barcode>>, OnFailureListener 
         if (image != null) {
             detector.process(image)
                 .addOnSuccessListener(this)
-                .addOnFailureListener(this);
+                .addOnFailureListener(this)
+                .addOnCompleteListener(task -> processLatest());
         }
-        frame.close();
     }
 
     @Override
@@ -82,7 +84,6 @@ class QrDetector implements OnSuccessListener<List<Barcode>>, OnFailureListener 
         for (Barcode barcode : firebaseVisionBarcodes) {
             communicator.qrRead(barcode.getRawValue());
         }
-        processLatest();
     }
 
     @Override


### PR DESCRIPTION
When a failure occurs in processing then all following frames are ignored. This PR fixes it.

As you can see bellow we never call `processLatest` on errors, so in `QrDetector.detect` the `processingFrame` is never null. Also, there's an error which happens when we call `frame.close()` before it was used for processing.

```java
    @Override
    public void onSuccess(List<Barcode> firebaseVisionBarcodes) {
        for (Barcode barcode : firebaseVisionBarcodes) {
            communicator.qrRead(barcode.getRawValue());
        }
        processLatest();
    }

    @Override
    public void onFailure(@NonNull Exception e) {
        Log.w(TAG, "Barcode Reading Failure: ", e);
    }
```

You can reproduce the error using this:
```java
static boolean forceError = true;

    private void processFrame(Frame frame) {
        InputImage image;
        try {
            image = frame.toImage();
        } catch (IllegalStateException ex) {
            // ignore state exception from making frame to image
            // as the image may be closed already.
            return;
        }

        if (forceError) {
            frame.close();
            forceError = false;
        }

        if (image != null) {
            detector.process(image)
                .addOnSuccessListener(this)
                .addOnFailureListener(this);
        }
    }
```