### PR TITLE
Fixing Hot Reload

### DIFF
--- a/lib/src/qr_camera.dart
+++ b/lib/src/qr_camera.dart
@@ -58,6 +58,12 @@ class QrCameraState extends State<QrCamera> with WidgetsBindingObserver {
   }
 
   @override
+  void reassemble() {
+    restart();
+    super.reassemble();
+  }
+
+  @override
   dispose() {
     _ambiguate(WidgetsBinding.instance)!.removeObserver(this);
     super.dispose();


### PR DESCRIPTION
Yeah this isn't the greatest way to do this since the onError callback will still be triggered but there aren't many other options. We could of course just bypass this exact Exception right here: https://github.com/rmtmckenzie/flutter_qr_mobile_vision/blob/6b3299bb2dbcc223318a7eb96036afad8e098da4/lib/src/qr_camera.dart#L149 But I do not know if this is wanted.