### PR TITLE
Update device_info_plus dependency to be ^4.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   native_device_orientation: ^1.0.0
-  device_info_plus: ^3.0.0
+  device_info_plus: ^4.0.0
 
 false_secrets:
   - /example/android/app/google-services.json


### PR DESCRIPTION
This just updates the library requirements to be device_info_plus 4.0.0 and higher.

Some other packages have made this move and so there are conflicting demands if you're using the latest of both packages.