### PR TITLE
Updated device_info_plus to be <9.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   native_device_orientation: ^1.0.0
-  device_info_plus: '>=3.0.0 <5.0.0'
+  device_info_plus: '>=3.0.0 <9.0.0'
 
 false_secrets:
   - /example/android/app/google-services.json


### PR DESCRIPTION
device_info_plus has had significant updates. This allows for 8.0.0 to be used in consuming projects.