### PR TITLE
Use the same camera device for the lamp as is showing on the screen.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -39,6 +39,9 @@ class _MyAppState extends State<MyApp> {
     return Scaffold(
       appBar: AppBar(
         title: Text('Plugin example app'),
+        actions: <Widget>[
+          IconButton(icon: new Icon(Icons.light), onPressed: _swapBackLightState),
+        ],
       ),
       body: Center(
         child: Column(
@@ -99,5 +102,9 @@ class _MyAppState extends State<MyApp> {
             });
           }),
     );
+  }
+
+  _swapBackLightState() async {
+    QrCamera.toggleFlash();
   }
 }

--- a/ios/Classes/QrReader.swift
+++ b/ios/Classes/QrReader.swift
@@ -190,8 +190,8 @@ class QrReader: NSObject {
   
   func toggleTorch(on: Bool) {
     guard
-      let device = AVCaptureDevice.default(for: AVMediaType.video),
-      device.hasTorch
+        let device = captureDevice ?? AVCaptureDevice.default(for: AVMediaType.video),
+        device.hasTorch
     else { return }
     
     do {


### PR DESCRIPTION
Use the existing capture device to use the lamp if it's not null. Also add a light button to the example.

Fixes https://github.com/rmtmckenzie/flutter_qr_mobile_vision/issues/222.

As an alternative, you may want to replicate the behavior of finding the initial camera as used in the constructor.