### PR TITLE
Change REQUEST_PERMISSION to unique code

### DIFF
--- a/android/src/main/java/com/github/rmtmckenzie/qr_mobile_vision/QrMobileVisionPlugin.java
+++ b/android/src/main/java/com/github/rmtmckenzie/qr_mobile_vision/QrMobileVisionPlugin.java
@@ -32,7 +32,7 @@ import io.flutter.view.TextureRegistry;
  */
 public class QrMobileVisionPlugin implements FlutterPlugin, MethodCallHandler, ActivityAware, PluginRegistry.RequestPermissionsResultListener, QrReaderCallbacks, QrReader.QRReaderStartedCallback {
   private static final String TAG = "cgr.qrmv.QrMobVisPlugin";
-  private static final int REQUEST_PERMISSION = 1;
+  private static final int REQUEST_PERMISSION = 1934726;
   private MethodChannel channel;
   private ActivityPluginBinding activityBinding;
 


### PR DESCRIPTION
I discovered a problem: the qr_mobile_vision package and flutter_local_notifications use the same code to request permissions, and it causes an error when used together.

The solution is to modify the REQUEST_PERMISSION field to a unique code.

Package: qr_mobile_vision
File: QrMobileVisionPlugin.java
```
private static final int REQUEST_PERMISSION = 1;
```

Package: flutter_local_notifications
File: FlutterLocalNotificationsPlugin.java
```
static final int NOTIFICATION_PERMISSION_REQUEST_CODE = 1;
```

Open Issues:
https://github.com/rmtmckenzie/flutter_qr_mobile_vision/issues/236
https://github.com/rmtmckenzie/flutter_qr_mobile_vision/issues/207