### PR TITLE
Add a naming 'as' to prevent a "Preview" class conflict with widgets

### DIFF
--- a/lib/src/qr_camera.dart
+++ b/lib/src/qr_camera.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 import 'package:qr_mobile_vision/qr_mobile_vision.dart';
-import 'package:qr_mobile_vision/src/preview.dart';
+import 'package:qr_mobile_vision/src/preview.dart' as qr_camera_preview;
 import 'package:qr_mobile_vision/src/preview_details.dart';
 
 Widget _defaultNotStartedBuilder(BuildContext context) => const Text("Camera Loading ...");
@@ -157,7 +157,7 @@ class QrCameraState extends State<QrCamera> with WidgetsBindingObserver {
               Widget preview = SizedBox(
                 width: constraints.maxWidth,
                 height: constraints.maxHeight,
-                child: Preview(
+                child: qr_camera_preview.Preview(
                   previewDetails: details.data!,
                   targetWidth: constraints.maxWidth,
                   targetHeight: constraints.maxHeight,


### PR DESCRIPTION
This just adds a naming prefix to the Preview class to prevent a conflict with the new Flutter 3.32.0 Widgets Preview class.

This addresses https://github.com/rmtmckenzie/flutter_qr_mobile_vision/issues/245.